### PR TITLE
fix: change CORS to allow origin `app://-`

### DIFF
--- a/bin/station-wallet-screening.js
+++ b/bin/station-wallet-screening.js
@@ -26,7 +26,7 @@ Sentry.init({
   tracesSampleRate: 0.1
 })
 
-assert(CHAINALYSIS_API_KEY)
+assert(CHAINALYSIS_API_KEY, 'CHAINALYSIS_API_KEY must be set via env vars')
 
 const server = http.createServer(createHandler({
   apiKey: CHAINALYSIS_API_KEY


### PR DESCRIPTION
The origin of the Electron app depends on how we run the app.
 - via `npm start` -> origin is http://localhost:3000
 - packaged -> origin is app://-

In this commit, I am changing our CORS header to be either `http://localhost:3000` or `app://-`, depending on what the client sends in the request header "Origin".
