### PR TITLE
feat: configurable request logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 # Set production environment
 ENV NODE_ENV="production"
 ENV SENTRY_ENVIRONMENT="production"
-ENV REQUEST_LOGGING false
+ENV REQUEST_LOGGING="false"
 
 # Throw-away build stage to reduce size of final image
 FROM base as build

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /app
 # Set production environment
 ENV NODE_ENV="production"
 ENV SENTRY_ENVIRONMENT="production"
+ENV REQUEST_LOGGING false
 
 # Throw-away build stage to reduce size of final image
 FROM base as build

--- a/bin/station-wallet-screening.js
+++ b/bin/station-wallet-screening.js
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url'
 const {
   PORT = 3000,
   CHAINALYSIS_API_KEY,
+  REQUEST_LOGGING = 'true',
   SENTRY_ENVIRONMENT = 'development'
 } = process.env
 
@@ -28,8 +29,15 @@ Sentry.init({
 
 assert(CHAINALYSIS_API_KEY, 'CHAINALYSIS_API_KEY must be set via env vars')
 
+const logger = {
+  error: console.error,
+  info: console.info,
+  request: ['1', 'true'].includes(REQUEST_LOGGING) ? console.info : () => {}
+}
+
 const server = http.createServer(createHandler({
-  apiKey: CHAINALYSIS_API_KEY
+  apiKey: CHAINALYSIS_API_KEY,
+  logger
 }))
 server.listen(PORT)
 await once(server, 'listening')

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ const handler = async (req, res, apiKey, fetch) => {
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
   // > Only a single origin can be specified. If the server supports clients from multiple origins,
   // > it must return the origin for the specific client making the request.
-  console.log('origin:', req.headers.origin)
   if (req.headers.origin === 'http://localhost:3000') {
     res.setHeader('Access-Control-Allow-Origin', 'http://localhost:3000')
   } else {
@@ -43,18 +42,18 @@ const handler = async (req, res, apiKey, fetch) => {
 export const createHandler = ({
   apiKey,
   fetch = globalThis.fetch,
-  log = console.log
+  logger
 }) => (req, res) => {
   const start = new Date()
-  log(`${req.method} ${req.url} ...`)
+  logger.request(`${req.method} ${req.url} ...`)
   handler(req, res, apiKey, fetch)
     .catch(err => {
-      log(err)
+      logger.error(err)
       Sentry.captureException(err)
       res.statusCode = 500
       res.end('Internal Server Error')
     })
     .then(() => {
-      log(`${req.method} ${req.url} ${res.statusCode} (${new Date() - start}ms)`)
+      logger.request(`${req.method} ${req.url} ${res.statusCode} (${new Date() - start}ms)`)
     })
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -6,13 +6,20 @@ import assert from 'node:assert'
 const { CHAINALYSIS_API_KEY } = process.env
 assert(CHAINALYSIS_API_KEY)
 
+const logger = {
+  info () {},
+  error: console.error,
+  request () {}
+}
+
 describe('Integration', () => {
   let server
   let port
 
   before(async () => {
     server = http.createServer(createHandler({
-      apiKey: CHAINALYSIS_API_KEY
+      apiKey: CHAINALYSIS_API_KEY,
+      logger
     }))
     server.listen()
     await once(server, 'listening')

--- a/test/unit.js
+++ b/test/unit.js
@@ -3,6 +3,12 @@ import http from 'node:http'
 import { once } from 'node:events'
 import assert from 'node:assert'
 
+const logger = {
+  info () {},
+  error: console.error,
+  request () {}
+}
+
 describe('Unit tests', () => {
   let server
   let port
@@ -26,7 +32,7 @@ describe('Unit tests', () => {
           json: async () => ({ identifications: [] })
         }
       },
-      log () {}
+      logger
     }))
 
     const { status } = await fetch(`http://127.0.0.1:${port}/0xADDRESS`)
@@ -54,7 +60,7 @@ describe('Unit tests', () => {
           json: async () => ({ identifications: [{}] })
         }
       },
-      log () {}
+      logger
     }))
 
     const { status } = await fetch(`http://127.0.0.1:${port}/0xADDRESS`)
@@ -81,7 +87,10 @@ describe('Unit tests', () => {
           status: 500
         }
       },
-      log () {}
+      logger: {
+        ...logger,
+        error () {}
+      }
     }))
 
     const { status } = await fetch(`http://127.0.0.1:${port}/0xADDRESS`)


### PR DESCRIPTION
Also don't print request logs when running in Docker (on Fly.io).

Inspired by filecoin-station/spark-api#159
